### PR TITLE
Arel is bundled with activerecord in rails 6.0+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,12 +13,12 @@ group :development, :test do
   gem "activerecord-jdbcpostgresql-adapter", :platforms => :jruby
 
   gem "tiny_tds", '~> 1.3.0' ,:require => false, :platforms => [:mri,:mingw, :x64_mingw, :mswin]
-  gem "activerecord-sqlserver-adapter", '~> 4.2.0', :platforms => [:mri, :mingw, :x64_mingw, :mswin]
+  #gem "activerecord-sqlserver-adapter", '~> 5.2.0', :platforms => [:mri, :mingw, :x64_mingw, :mswin]
 
   gem 'ruby-oci8', :platforms => [:mri, :mswin, :x64_mingw, :mingw]
   gem 'activerecord-oracle_enhanced-adapter', '~> 1.6.0'
 
-  gem 'activesupport', '~> 4.0'
-  gem 'activemodel', '~> 4.0'
-  gem 'activerecord', '~> 4.0'
+  gem 'activesupport', '~> 6.0'
+  gem 'activemodel', '~> 6.0'
+  gem 'activerecord', '~> 6.0'
 end

--- a/arel_extensions.gemspec
+++ b/arel_extensions.gemspec
@@ -20,7 +20,9 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths = ["lib"]
 
-  s.add_dependency('arel', '>= 6.0')
+  # AJLA -- arel is bundled with activerecord in rails 6
+  #s.add_dependency('arel', '>= 6.0')
+  s.add_dependency('activerecord', '~> 6.0')
 
   s.add_development_dependency('minitest', '~> 5.9')
   s.add_development_dependency('rdoc', '~> 4.0')


### PR DESCRIPTION
Removed direct dependency on `arel` in favor of `activerecord` for rails 6.0+ support. Had to remove dependency on `activerecord-sqlserver-adapter` since that has not been updated to support rails 6 either. Shouldn't be an issue for RapidStorm since we don't use SQL server.

We'll need to circle back around and once this gem is updated so that we can depend on the main branch.